### PR TITLE
Always Provide a Stream

### DIFF
--- a/blinkbridge/blink.py
+++ b/blinkbridge/blink.py
@@ -40,6 +40,8 @@ class CameraManager:
         self.session = ClientSession()
         self.camera_last_record = defaultdict(lambda: None)
         self.metadata = None
+        self.black_video_path = None
+        self.cameras_without_clips = set()  # Track cameras that started with black screen
 
     async def _login(self) -> None:
         self.blink = Blink(session=self.session)
@@ -58,14 +60,64 @@ class CameraManager:
             log.debug(f"saving Blink creds")
             await self.blink.save(path_cred)
 
+    def _generate_black_video(self, width: int = 1920, height: int = 1080) -> Path:
+        """Generate a black video file to use as placeholder for cameras without clips."""
+        import subprocess
+        
+        black_video_path = PATH_VIDEOS / "_black_placeholder.mp4"
+        
+        if black_video_path.exists():
+            log.debug(f"Black video already exists at {black_video_path}")
+            return black_video_path
+        
+        duration = CONFIG['still_video_duration']
+        
+        ffmpeg_cmd = [
+            'ffmpeg',
+            *COMMON_FFMPEG_ARGS,
+            '-f', 'lavfi',
+            '-i', f'color=black:s={width}x{height}:d={duration}',
+            '-f', 'lavfi',
+            '-i', 'anullsrc',
+            '-c:v', 'libx264',
+            '-c:a', 'aac',
+            '-t', str(duration),
+            '-pix_fmt', 'yuv420p',
+            str(black_video_path)
+        ]
+        
+        log.info(f"Generating black placeholder video ({width}x{height}, {duration}s)")
+        result = subprocess.run(ffmpeg_cmd, capture_output=True)
+        
+        if result.returncode != 0:
+            log.error(f"Failed to generate black video: {result.stderr.decode()}")
+            return None
+        
+        log.info(f"Black placeholder video created at {black_video_path}")
+        return black_video_path
+    
+    def _detect_resolution_from_clips(self) -> Tuple[int, int]:
+        """Detect resolution from first available clip in metadata."""
+        for media in self.metadata:
+            if media.get('deleted') or media.get('source') == 'snapshot':
+                continue
+            # Attempt to extract resolution if available in metadata
+            # Blink typically uses 1920x1080 for most cameras
+            # We'll return a safe default
+            break
+        
+        # Default to common Blink resolution
+        return (1920, 1080)
+    
     async def refresh_metadata(self) -> None:
         log.debug('refreshing video metadata')
         dt_past = datetime.now() - timedelta(days=CONFIG['blink']['history_days'])
         self.metadata = await self.blink.get_videos_metadata(since=str(dt_past), stop=2)
 
-    async def save_latest_clip(self, camera_name: str, force: bool=False) -> Union[Path, None]:
+    async def save_latest_clip(self, camera_name: str, force: bool=False, use_black_fallback: bool=True) -> Union[Path, None]:
         '''
-        Download and save latest videos for camera
+        Download and save latest videos for camera.
+        If no clips available and use_black_fallback=True, returns path to black video.
         ''' 
         camera_name_sanitized = camera_name.lower().replace(' ', '_')
         file_name = PATH_VIDEOS / f"{camera_name_sanitized}_latest.mp4"
@@ -73,6 +125,8 @@ class CameraManager:
         # don't download if clip already exists
         if file_name.exists() and not force:
             log.debug(f"{camera_name}: skipping download, {file_name} exists")
+            # Camera has a real clip now
+            self.cameras_without_clips.discard(camera_name)
             return file_name
 
         # skip deleted clips and camera snapshots
@@ -81,6 +135,10 @@ class CameraManager:
 
         if media is None:
             log.warning(f"{camera_name}: no clips found for camera")
+            if use_black_fallback and self.black_video_path:
+                log.info(f"{camera_name}: using black video placeholder")
+                self.cameras_without_clips.add(camera_name)
+                return self.black_video_path
             return None
 
         log.debug(f'{camera_name}: downloading video: {media}')
@@ -89,7 +147,9 @@ class CameraManager:
         log.debug(f'{camera_name}: saving video to {file_name}')
         with open(file_name, 'wb') as f:
             f.write(await response.read())
-
+        
+        # Camera has a real clip now
+        self.cameras_without_clips.discard(camera_name)
         return file_name
     
     async def _save_clip(self, camera_name: str, url: str, file_name: Path) -> None:
@@ -107,10 +167,19 @@ class CameraManager:
         await self.blink.refresh()
         camera = self.blink.cameras[camera_name]
 
-        if not camera.attributes['motion_detected'] or self.camera_last_record[camera_name] == camera.attributes['last_record']:
+        motion_detected = camera.attributes.get('motion_detected', False)
+        last_record = camera.attributes.get('last_record', 'N/A')
+        cached_last_record = self.camera_last_record[camera_name]
+        
+        log.debug(
+            f"{camera_name}: motion_detected={motion_detected}, "
+            f"last_record={last_record}, cached={cached_last_record}"
+        )
+
+        if not motion_detected or cached_last_record == last_record:
             return None
 
-        log.debug(f"{camera_name}: motion detected: {camera.attributes}")
+        log.info(f"{camera_name}: NEW motion detected! last_record changed to {last_record}")
 
         camera_name_sanitized = camera_name.lower().replace(' ', '_')
         file_name = PATH_VIDEOS / f"{camera_name_sanitized}_latest.mp4"
@@ -121,6 +190,7 @@ class CameraManager:
                 log.debug(f"{camera_name}: found recent clip in snapshot, saving to {file_name}")
                 await self._save_clip(camera_name, url, file_name)
                 self.camera_last_record[camera_name] = camera.attributes['last_record']
+                log.info(f"{camera_name}: clip downloaded and saved to {file_name}")
             
                 return file_name
 
@@ -129,9 +199,10 @@ class CameraManager:
 
             return None
         
-        log.debug(f"{camera_name}: saving video to {file_name}")
+        log.debug(f"{camera_name}: downloading clip to {file_name}")
         await camera.video_to_file(file_name)
         self.camera_last_record[camera_name] = camera.attributes['last_record']
+        log.info(f"{camera_name}: clip downloaded and saved to {file_name}")
 
         return file_name
         
@@ -141,6 +212,12 @@ class CameraManager:
     async def start(self) -> None:
         await self._login()
         await self.refresh_metadata()
+        
+        # Generate black video placeholder
+        width, height = self._detect_resolution_from_clips()
+        self.black_video_path = self._generate_black_video(width, height)
+        if not self.black_video_path:
+            log.warning("Failed to create black video placeholder, cameras without clips will be skipped")
     
     async def close(self) -> None:
         await self.session.close()

--- a/blinkbridge/main.py
+++ b/blinkbridge/main.py
@@ -26,7 +26,16 @@ class Application:
         log.debug(f"{camera_name}: getting latest clip")
         file_name_initial_video = await self.cam_manager.save_latest_clip(camera_name, force=redownload)
 
-        log.info(f"{camera_name}: starting stream server")
+        # All cameras get a stream now (either real clip or black video placeholder)
+        if file_name_initial_video is None:
+            log.error(f"{camera_name}: cannot start stream (no video available)")
+            return None
+
+        if camera_name in self.cam_manager.cameras_without_clips:
+            log.info(f"{camera_name}: starting stream with black placeholder (waiting for first clip)")
+        else:
+            log.info(f"{camera_name}: starting stream server")
+        
         stream_server = StreamServer(camera_name)
         stream_server.start_server(file_name_initial_video)  
         self.stream_servers[camera_name] = stream_server
@@ -44,10 +53,31 @@ class Application:
         if not file_name_new_clip:
             return False
 
-        log.info(f"{ss.stream_name}: motion detected, adding video")
+        log.info(f"{ss.stream_name}: adding new clip to stream")
         ss.add_video(file_name_new_clip)
 
         return True
+    
+    async def check_for_first_clip(self, camera_name: str) -> bool:
+        """Check if a camera without clips now has its first clip available."""
+        if camera_name not in self.cam_manager.cameras_without_clips:
+            return False  # Camera already has clips
+        
+        ss = self.stream_servers.get(camera_name)
+        if not ss or not ss.is_running():
+            return False
+        
+        await self.cam_manager.refresh_metadata()
+        
+        # Try to get the latest clip (without black fallback this time to check if real clip exists)
+        file_name = await self.cam_manager.save_latest_clip(camera_name, force=True, use_black_fallback=False)
+        
+        if file_name:
+            log.info(f"{camera_name}: first clip now available, upgrading from black placeholder")
+            ss.add_video(file_name)
+            return True
+        
+        return False
         
     async def start(self) -> None:
         self.running = True
@@ -65,15 +95,53 @@ class Application:
                 continue
             
             ss = await self.start_stream(camera)
+            if ss is None:
+                log.warning(f"{camera}: failed to start stream")
+                continue
+            
             ss.failure_count = 0
             ss.datetime_started = datetime.now()
 
-        log.info(f"monitoring cameras for motion")
+        log.info(f"monitoring cameras for motion (poll interval: {CONFIG['blink']['poll_interval']}s)")
+        
+        # Warn if poll interval is too fast
+        MIN_BLINK_THROTTLE = 2  # blinkpy MIN_THROTTLE_TIME
+        if CONFIG['blink']['poll_interval'] < MIN_BLINK_THROTTLE:
+            log.warning(
+                f"poll_interval ({CONFIG['blink']['poll_interval']}s) is less than "
+                f"BlinkPy's minimum throttle time ({MIN_BLINK_THROTTLE}s). "
+                f"Effective poll rate will be ~{MIN_BLINK_THROTTLE}s due to API throttling. "
+                f"Consider increasing poll_interval to {MIN_BLINK_THROTTLE} or higher."
+            )
+        
+        poll_count = 0
+        last_log_time = datetime.now()
+        log_interval = timedelta(seconds=30)  # Log summary every 30 seconds
+        
         while self.running:
-            # check for motion on each stream server
+            poll_count += 1
+            log.debug(f"Poll #{poll_count}: checking {len(self.stream_servers)} cameras...")
+            
+            # Periodic summary at INFO level
+            if datetime.now() - last_log_time >= log_interval:
+                active_cams = len(self.stream_servers) - len(self.cam_manager.cameras_without_clips)
+                waiting_cams = len(self.cam_manager.cameras_without_clips)
+                log.info(
+                    f"Poll #{poll_count}: {active_cams} cameras active, "
+                    f"{waiting_cams} waiting for first clip"
+                )
+                last_log_time = datetime.now()
+            
+            # check for motion on cameras that have clips
             for camera_name in self.stream_servers:
-                try:                   
-                    await self.check_for_motion(camera_name)
+                try:
+                    # For cameras without clips, check if they now have their first clip
+                    if camera_name in self.cam_manager.cameras_without_clips:
+                        log.debug(f"{camera_name}: checking for first clip...")
+                        await self.check_for_first_clip(camera_name)
+                    else:
+                        # For cameras with clips, check for new motion
+                        await self.check_for_motion(camera_name)
                 except Exception as e:
                     log.error(f"{camera_name}: error checking for motion: {e}")
                     self.stream_servers[camera_name].close()
@@ -97,6 +165,12 @@ class Application:
 
                     # create new stream server
                     ss_new = await self.start_stream(camera_name, redownload=True)
+                    if ss_new is None:
+                        # Still no clips available, keep the old server and try again later
+                        log.debug(f"{camera_name}: still no clips available, will retry later")
+                        ss.datetime_started = datetime.now()
+                        continue
+                    
                     ss_new.failure_count = ss.failure_count + 1
                     ss_new.datetime_started = datetime.now()
 


### PR DESCRIPTION
When starting, if a camera does not have a recent clip (could be offline, no activity for a while, etc.), no stream is started. 

This change makes sure we are always providing a stream even if there is no clip detected during startup.