### PR TITLE
Properly Close Connections

### DIFF
--- a/blinkbridge/blink.py
+++ b/blinkbridge/blink.py
@@ -143,7 +143,19 @@ class CameraManager:
         await self.refresh_metadata()
     
     async def close(self) -> None:
-        await self.session.close()
+        """Properly close all connections and clean up resources."""
+        # Close the Blink object first if it exists
+        if hasattr(self, 'blink') and self.blink is not None:
+            # Close the Blink auth session if it exists
+            if hasattr(self.blink, 'auth') and self.blink.auth is not None:
+                if hasattr(self.blink.auth, 'session') and self.blink.auth.session is not None:
+                    if not self.blink.auth.session.closed:
+                        await self.blink.auth.session.close()
+            
+        # Close our own session
+        if hasattr(self, 'session') and self.session is not None:
+            if not self.session.closed:
+                await self.session.close()
 
 async def test() -> None:
     cm = CameraManager()

--- a/blinkbridge/blink.py
+++ b/blinkbridge/blink.py
@@ -144,18 +144,13 @@ class CameraManager:
     
     async def close(self) -> None:
         """Properly close all connections and clean up resources."""
-        # Close the Blink object first if it exists
-        if hasattr(self, 'blink') and self.blink is not None:
-            # Close the Blink auth session if it exists
-            if hasattr(self.blink, 'auth') and self.blink.auth is not None:
-                if hasattr(self.blink.auth, 'session') and self.blink.auth.session is not None:
-                    if not self.blink.auth.session.closed:
-                        await self.blink.auth.session.close()
-            
-        # Close our own session
+        # Close the session only once (blink.auth.session is the same as self.session)
         if hasattr(self, 'session') and self.session is not None:
             if not self.session.closed:
                 await self.session.close()
+                # Give the event loop time to clean up SSL transports
+                # This prevents "Unclosed connector" warnings
+                await asyncio.sleep(0.25)
 
 async def test() -> None:
     cm = CameraManager()


### PR DESCRIPTION
When shutting down, we aren't properly closing connections, leading to output such as the following:
```
blinkbridge-1  | [20:31:37] INFO     Shutting down...                                 main.py:136
blinkbridge-1  |            ERROR    Unclosed client session                  base_events.py:1864
blinkbridge-1  |                     client_session:                                             
blinkbridge-1  |                     <aiohttp.client.ClientSession object at                     
blinkbridge-1  |                     0x7d0b61f4cb90>                                             
blinkbridge-1  |            ERROR    Unclosed connector                       base_events.py:1864
blinkbridge-1  |                     connections:                                                
blinkbridge-1  |                     ['deque([(<aiohttp.client_proto.Response                    
blinkbridge-1  |                     Handler object at 0x7d0b61f619d0>,                          
blinkbridge-1  |                     21014.124165045)])']                                        
blinkbridge-1  |                     connector:                                                  
blinkbridge-1  |                     <aiohttp.connector.TCPConnector object                      
blinkbridge-1  |                     at 0x7d0b61f4ccd0>                                     
```

This PR properly checks and closes connections, adding a small wait for connections to close properly.