### PR TITLE
Fix Stream Startup Errors

### DIFF
--- a/blinkbridge/blink.py
+++ b/blinkbridge/blink.py
@@ -40,6 +40,8 @@ class CameraManager:
         self.session = ClientSession()
         self.camera_last_record = defaultdict(lambda: None)
         self.metadata = None
+        self.black_video_path = None
+        self.cameras_without_clips = set()  # Track cameras that started with black screen
 
     async def _login(self) -> None:
         self.blink = Blink(session=self.session)
@@ -58,14 +60,64 @@ class CameraManager:
             log.debug(f"saving Blink creds")
             await self.blink.save(path_cred)
 
+    def _generate_black_video(self, width: int = 1920, height: int = 1080) -> Path:
+        """Generate a black video file to use as placeholder for cameras without clips."""
+        import subprocess
+        
+        black_video_path = PATH_VIDEOS / "_black_placeholder.mp4"
+        
+        if black_video_path.exists():
+            log.debug(f"Black video already exists at {black_video_path}")
+            return black_video_path
+        
+        duration = CONFIG['still_video_duration']
+        
+        ffmpeg_cmd = [
+            'ffmpeg',
+            *COMMON_FFMPEG_ARGS,
+            '-f', 'lavfi',
+            '-i', f'color=black:s={width}x{height}:d={duration}',
+            '-f', 'lavfi',
+            '-i', 'anullsrc',
+            '-c:v', 'libx264',
+            '-c:a', 'aac',
+            '-t', str(duration),
+            '-pix_fmt', 'yuv420p',
+            str(black_video_path)
+        ]
+        
+        log.info(f"Generating black placeholder video ({width}x{height}, {duration}s)")
+        result = subprocess.run(ffmpeg_cmd, capture_output=True)
+        
+        if result.returncode != 0:
+            log.error(f"Failed to generate black video: {result.stderr.decode()}")
+            return None
+        
+        log.info(f"Black placeholder video created at {black_video_path}")
+        return black_video_path
+    
+    def _detect_resolution_from_clips(self) -> Tuple[int, int]:
+        """Detect resolution from first available clip in metadata."""
+        for media in self.metadata:
+            if media.get('deleted') or media.get('source') == 'snapshot':
+                continue
+            # Attempt to extract resolution if available in metadata
+            # Blink typically uses 1920x1080 for most cameras
+            # We'll return a safe default
+            break
+        
+        # Default to common Blink resolution
+        return (1920, 1080)
+    
     async def refresh_metadata(self) -> None:
         log.debug('refreshing video metadata')
         dt_past = datetime.now() - timedelta(days=CONFIG['blink']['history_days'])
         self.metadata = await self.blink.get_videos_metadata(since=str(dt_past), stop=2)
 
-    async def save_latest_clip(self, camera_name: str, force: bool=False) -> Union[Path, None]:
+    async def save_latest_clip(self, camera_name: str, force: bool=False, use_black_fallback: bool=True) -> Union[Path, None]:
         '''
-        Download and save latest videos for camera
+        Download and save latest videos for camera.
+        If no clips available and use_black_fallback=True, returns path to black video.
         ''' 
         camera_name_sanitized = camera_name.lower().replace(' ', '_')
         file_name = PATH_VIDEOS / f"{camera_name_sanitized}_latest.mp4"
@@ -73,6 +125,8 @@ class CameraManager:
         # don't download if clip already exists
         if file_name.exists() and not force:
             log.debug(f"{camera_name}: skipping download, {file_name} exists")
+            # Camera has a real clip now
+            self.cameras_without_clips.discard(camera_name)
             return file_name
 
         # skip deleted clips and camera snapshots
@@ -81,6 +135,10 @@ class CameraManager:
 
         if media is None:
             log.warning(f"{camera_name}: no clips found for camera")
+            if use_black_fallback and self.black_video_path:
+                log.info(f"{camera_name}: using black video placeholder")
+                self.cameras_without_clips.add(camera_name)
+                return self.black_video_path
             return None
 
         log.debug(f'{camera_name}: downloading video: {media}')
@@ -89,7 +147,9 @@ class CameraManager:
         log.debug(f'{camera_name}: saving video to {file_name}')
         with open(file_name, 'wb') as f:
             f.write(await response.read())
-
+        
+        # Camera has a real clip now
+        self.cameras_without_clips.discard(camera_name)
         return file_name
     
     async def _save_clip(self, camera_name: str, url: str, file_name: Path) -> None:
@@ -107,10 +167,19 @@ class CameraManager:
         await self.blink.refresh()
         camera = self.blink.cameras[camera_name]
 
-        if not camera.attributes['motion_detected'] or self.camera_last_record[camera_name] == camera.attributes['last_record']:
+        motion_detected = camera.attributes.get('motion_detected', False)
+        last_record = camera.attributes.get('last_record', 'N/A')
+        cached_last_record = self.camera_last_record[camera_name]
+        
+        log.debug(
+            f"{camera_name}: motion_detected={motion_detected}, "
+            f"last_record={last_record}, cached={cached_last_record}"
+        )
+
+        if not motion_detected or cached_last_record == last_record:
             return None
 
-        log.debug(f"{camera_name}: motion detected: {camera.attributes}")
+        log.info(f"{camera_name}: NEW motion detected! last_record changed to {last_record}")
 
         camera_name_sanitized = camera_name.lower().replace(' ', '_')
         file_name = PATH_VIDEOS / f"{camera_name_sanitized}_latest.mp4"
@@ -121,6 +190,7 @@ class CameraManager:
                 log.debug(f"{camera_name}: found recent clip in snapshot, saving to {file_name}")
                 await self._save_clip(camera_name, url, file_name)
                 self.camera_last_record[camera_name] = camera.attributes['last_record']
+                log.info(f"{camera_name}: clip downloaded and saved to {file_name}")
             
                 return file_name
 
@@ -129,9 +199,10 @@ class CameraManager:
 
             return None
         
-        log.debug(f"{camera_name}: saving video to {file_name}")
+        log.debug(f"{camera_name}: downloading clip to {file_name}")
         await camera.video_to_file(file_name)
         self.camera_last_record[camera_name] = camera.attributes['last_record']
+        log.info(f"{camera_name}: clip downloaded and saved to {file_name}")
 
         return file_name
         
@@ -141,6 +212,12 @@ class CameraManager:
     async def start(self) -> None:
         await self._login()
         await self.refresh_metadata()
+        
+        # Generate black video placeholder
+        width, height = self._detect_resolution_from_clips()
+        self.black_video_path = self._generate_black_video(width, height)
+        if not self.black_video_path:
+            log.warning("Failed to create black video placeholder, cameras without clips will be skipped")
     
     async def close(self) -> None:
         await self.session.close()

--- a/blinkbridge/blink.py
+++ b/blinkbridge/blink.py
@@ -41,7 +41,8 @@ class CameraManager:
         self.camera_last_record = defaultdict(lambda: None)
         self.metadata = None
         self.black_video_path = None
-        self.cameras_without_clips = set()  # Track cameras that started with black screen
+        self.cameras_without_clips = set()  # Track cameras that currently don't have clips
+        self.cameras_ever_had_real_clip = set()  # Track cameras that have ever had a real clip (permanent within run)
 
     async def _login(self) -> None:
         """Login to Blink using OAuth v2 authentication."""
@@ -109,11 +110,17 @@ class CameraManager:
             '-f', 'lavfi',
             '-i', f'color=black:s={width}x{height}:d={duration}',
             '-f', 'lavfi',
-            '-i', 'anullsrc',
+            '-i', f'anullsrc=channel_layout=stereo:sample_rate=44100',
             '-c:v', 'libx264',
+            '-profile:v', 'high',
+            '-level:v', '4.1',
             '-c:a', 'aac',
+            '-ar', '44100',
+            '-ac', '2',
+            '-b:a', '128k',
             '-t', str(duration),
             '-pix_fmt', 'yuv420p',
+            '-movflags', 'faststart',
             str(black_video_path)
         ]
         
@@ -148,7 +155,8 @@ class CameraManager:
     async def save_latest_clip(self, camera_name: str, force: bool=False, use_black_fallback: bool=True) -> Union[Path, None]:
         '''
         Download and save latest videos for camera.
-        If no clips available and use_black_fallback=True, returns path to black video.
+        If no clips available and use_black_fallback=True AND camera never had a real clip, returns path to black video.
+        Once a camera has had a real clip, it will never fall back to black screen.
         ''' 
         camera_name_sanitized = camera_name.lower().replace(' ', '_')
         file_name = PATH_VIDEOS / f"{camera_name_sanitized}_latest.mp4"
@@ -156,8 +164,10 @@ class CameraManager:
         # don't download if clip already exists
         if file_name.exists() and not force:
             log.debug(f"{camera_name}: skipping download, {file_name} exists")
-            # Camera has a real clip now
-            self.cameras_without_clips.discard(camera_name)
+            # If this is a cached real clip (not black video), mark as having had real clip
+            if file_name != self.black_video_path:
+                self.cameras_without_clips.discard(camera_name)
+                self.cameras_ever_had_real_clip.add(camera_name)
             return file_name
 
         # skip deleted clips and camera snapshots
@@ -166,22 +176,35 @@ class CameraManager:
 
         if media is None:
             log.warning(f"{camera_name}: no clips found for camera")
-            if use_black_fallback and self.black_video_path:
-                log.info(f"{camera_name}: using black video placeholder")
+            # Only use black fallback if camera has NEVER had a real clip
+            if use_black_fallback and self.black_video_path and camera_name not in self.cameras_ever_had_real_clip:
+                log.info(f"{camera_name}: using black video placeholder (never had real clip)")
                 self.cameras_without_clips.add(camera_name)
                 return self.black_video_path
+            elif camera_name in self.cameras_ever_had_real_clip:
+                log.warning(f"{camera_name}: no new clips found, but camera has had real clips before - not falling back to black")
             return None
 
-        log.debug(f'{camera_name}: downloading video: {media}')
-        response = await self.blink.do_http_get(media['media'])
+        try:
+            log.debug(f'{camera_name}: downloading video: {media}')
+            response = await self.blink.do_http_get(media['media'])
 
-        log.debug(f'{camera_name}: saving video to {file_name}')
-        with open(file_name, 'wb') as f:
-            f.write(await response.read())
-        
-        # Camera has a real clip now
-        self.cameras_without_clips.discard(camera_name)
-        return file_name
+            log.debug(f'{camera_name}: saving video to {file_name}')
+            with open(file_name, 'wb') as f:
+                f.write(await response.read())
+            
+            # Camera has a real clip now (mark permanently)
+            self.cameras_without_clips.discard(camera_name)
+            self.cameras_ever_had_real_clip.add(camera_name)
+            log.debug(f"{camera_name}: successfully downloaded real clip")
+            return file_name
+        except Exception as e:
+            log.error(f"{camera_name}: failed to download clip: {e}")
+            # If download fails but camera had clips before, try to use cached file
+            if camera_name in self.cameras_ever_had_real_clip and file_name.exists():
+                log.warning(f"{camera_name}: using cached clip after download failure")
+                return file_name
+            return None
     
     async def _save_clip(self, camera_name: str, url: str, file_name: Path) -> None:
         camera = self.blink.cameras[camera_name]
@@ -221,6 +244,9 @@ class CameraManager:
                 log.debug(f"{camera_name}: found recent clip in snapshot, saving to {file_name}")
                 await self._save_clip(camera_name, url, file_name)
                 self.camera_last_record[camera_name] = camera.attributes['last_record']
+                # Mark as having real clip
+                self.cameras_without_clips.discard(camera_name)
+                self.cameras_ever_had_real_clip.add(camera_name)
                 log.info(f"{camera_name}: clip downloaded and saved to {file_name}")
             
                 return file_name
@@ -233,6 +259,9 @@ class CameraManager:
         log.debug(f"{camera_name}: downloading clip to {file_name}")
         await camera.video_to_file(file_name)
         self.camera_last_record[camera_name] = camera.attributes['last_record']
+        # Mark as having real clip
+        self.cameras_without_clips.discard(camera_name)
+        self.cameras_ever_had_real_clip.add(camera_name)
         log.info(f"{camera_name}: clip downloaded and saved to {file_name}")
 
         return file_name

--- a/blinkbridge/ffmpeg.py
+++ b/blinkbridge/ffmpeg.py
@@ -35,6 +35,11 @@ class StreamParameters:
 
         stream_audio = next((s for s in js if s['codec_name'] == 'aac'), {})
         stream_video = next((s for s in js if s['codec_name'] == 'h264'), {})
+        
+        if not stream_audio:
+            log.warning(f"No AAC audio stream found in video. Available codecs: {[s.get('codec_name') for s in js]}")
+        if not stream_video:
+            log.warning(f"No H264 video stream found in video. Available codecs: {[s.get('codec_name') for s in js]}")
 
         return stream_audio, stream_video
 
@@ -72,6 +77,15 @@ class FrameToVideo:
         time_base_denominator = params_video['time_base'].split('/')[1] # cut off "1/"
         fps_value = params_video['r_frame_rate']
         
+        # Use provided audio params or default to stereo 44.1kHz if no audio stream
+        if params_audio:
+            audio_channels = params_audio['channels']
+            audio_sample_rate = params_audio['sample_rate']
+        else:
+            log.info("No audio stream in source, generating silent audio track")
+            audio_channels = '2'
+            audio_sample_rate = '44100'
+        
         # Create the ffmpeg parameters list
         ffmpeg_params = [
             'ffmpeg',
@@ -79,7 +93,7 @@ class FrameToVideo:
             '-loop', '1',
             '-i', image_file_name,   
             '-f', 'lavfi',
-            '-i', f"anullsrc=channel_layout={params_audio['channels']}:sample_rate={params_audio['sample_rate']}",
+            '-i', f"anullsrc=channel_layout={audio_channels}:sample_rate={audio_sample_rate}",
             '-c:v', params_video['codec_name'],
             '-pix_fmt', params_video['pix_fmt'],
             '-t', str(output_duration),
@@ -91,8 +105,8 @@ class FrameToVideo:
             '-video_track_timescale', time_base_denominator,
             '-fps_mode', 'passthrough',
             '-c:a', 'aac',
-            '-ar', params_audio['sample_rate'],
-            '-ac', params_audio['channels'],
+            '-ar', audio_sample_rate,
+            '-ac', audio_channels,
             file_name_output_video
         ]    
 
@@ -110,6 +124,7 @@ class StillVideoCreator:
                  file_name_input_video: Union[str, Path], 
                  output_duration: float=1, 
                  file_name_still_video: Union[str, Path]="output.mp4"):
+        self.exception = None
         self.thread = threading.Thread(target=self._run, 
                                        args=(file_name_input_video, output_duration, file_name_still_video))
         self.thread.start() 
@@ -118,21 +133,34 @@ class StillVideoCreator:
              file_name_input_video: Union[str, Path], 
              output_duration: float=1, 
              file_name_still_video: Union[str, Path]="output.mp4") -> None:
-        still_image_file_name = PATH_VIDEOS / 'last_frame.jpg'
-        lfg = VideoToLastFrame(file_name_input_video, still_image_file_name) # run in background
-        params_audio, params_video = StreamParameters(file_name_input_video).wait()
-        lfg.wait()
+        try:
+            still_image_file_name = PATH_VIDEOS / 'last_frame.jpg'
+            lfg = VideoToLastFrame(file_name_input_video, still_image_file_name) # run in background
+            params_audio, params_video = StreamParameters(file_name_input_video).wait()
+            lfg.wait()
 
-        assert all((params_audio, params_video))
+            # Video stream is required, audio is optional
+            if not params_video:
+                error_msg = f"Failed to extract video stream (H264) from {file_name_input_video}. "
+                log.error(error_msg)
+                raise ValueError(error_msg)
+            
+            if not params_audio:
+                log.warning(f"No audio stream (AAC) found in {file_name_input_video}, will generate silent audio")
 
-        # convert to video
-        FrameToVideo(still_image_file_name, params_video, params_audio,
-                    output_duration=output_duration,
-                    file_name_output_video=file_name_still_video).wait()
-        
-        # remove temporary file
-        still_image_file_name.unlink()
+            # convert to video
+            FrameToVideo(still_image_file_name, params_video, params_audio,
+                        output_duration=output_duration,
+                        file_name_output_video=file_name_still_video).wait()
+            
+            # remove temporary file
+            still_image_file_name.unlink()
+        except Exception as e:
+            log.error(f"Error in StillVideoCreator: {e}")
+            self.exception = e
         
     def wait(self) -> None:
         self.thread.join()
+        if self.exception:
+            raise self.exception
     

--- a/blinkbridge/main.py
+++ b/blinkbridge/main.py
@@ -26,7 +26,16 @@ class Application:
         log.debug(f"{camera_name}: getting latest clip")
         file_name_initial_video = await self.cam_manager.save_latest_clip(camera_name, force=redownload)
 
-        log.info(f"{camera_name}: starting stream server")
+        # All cameras get a stream now (either real clip or black video placeholder)
+        if file_name_initial_video is None:
+            log.error(f"{camera_name}: cannot start stream (no video available)")
+            return None
+
+        if camera_name in self.cam_manager.cameras_without_clips:
+            log.info(f"{camera_name}: starting stream with black placeholder (waiting for first clip)")
+        else:
+            log.info(f"{camera_name}: starting stream server")
+        
         stream_server = StreamServer(camera_name)
         stream_server.start_server(file_name_initial_video)  
         self.stream_servers[camera_name] = stream_server
@@ -44,10 +53,31 @@ class Application:
         if not file_name_new_clip:
             return False
 
-        log.info(f"{ss.stream_name}: motion detected, adding video")
+        log.info(f"{ss.stream_name}: adding new clip to stream")
         ss.add_video(file_name_new_clip)
 
         return True
+    
+    async def check_for_first_clip(self, camera_name: str) -> bool:
+        """Check if a camera without clips now has its first clip available."""
+        if camera_name not in self.cam_manager.cameras_without_clips:
+            return False  # Camera already has clips
+        
+        ss = self.stream_servers.get(camera_name)
+        if not ss or not ss.is_running():
+            return False
+        
+        await self.cam_manager.refresh_metadata()
+        
+        # Try to get the latest clip (without black fallback this time to check if real clip exists)
+        file_name = await self.cam_manager.save_latest_clip(camera_name, force=True, use_black_fallback=False)
+        
+        if file_name:
+            log.info(f"{camera_name}: first clip now available, upgrading from black placeholder")
+            ss.add_video(file_name)
+            return True
+        
+        return False
         
     async def start(self) -> None:
         self.running = True
@@ -65,15 +95,53 @@ class Application:
                 continue
             
             ss = await self.start_stream(camera)
+            if ss is None:
+                log.warning(f"{camera}: failed to start stream")
+                continue
+            
             ss.failure_count = 0
             ss.datetime_started = datetime.now()
 
-        log.info(f"monitoring cameras for motion")
+        log.info(f"monitoring cameras for motion (poll interval: {CONFIG['blink']['poll_interval']}s)")
+        
+        # Warn if poll interval is too fast
+        MIN_BLINK_THROTTLE = 2  # blinkpy MIN_THROTTLE_TIME
+        if CONFIG['blink']['poll_interval'] < MIN_BLINK_THROTTLE:
+            log.warning(
+                f"poll_interval ({CONFIG['blink']['poll_interval']}s) is less than "
+                f"BlinkPy's minimum throttle time ({MIN_BLINK_THROTTLE}s). "
+                f"Effective poll rate will be ~{MIN_BLINK_THROTTLE}s due to API throttling. "
+                f"Consider increasing poll_interval to {MIN_BLINK_THROTTLE} or higher."
+            )
+        
+        poll_count = 0
+        last_log_time = datetime.now()
+        log_interval = timedelta(seconds=30)  # Log summary every 30 seconds
+        
         while self.running:
-            # check for motion on each stream server
+            poll_count += 1
+            log.debug(f"Poll #{poll_count}: checking {len(self.stream_servers)} cameras...")
+            
+            # Periodic summary at INFO level
+            if datetime.now() - last_log_time >= log_interval:
+                active_cams = len(self.stream_servers) - len(self.cam_manager.cameras_without_clips)
+                waiting_cams = len(self.cam_manager.cameras_without_clips)
+                log.info(
+                    f"Poll #{poll_count}: {active_cams} cameras active, "
+                    f"{waiting_cams} waiting for first clip"
+                )
+                last_log_time = datetime.now()
+            
+            # check for motion on cameras that have clips
             for camera_name in self.stream_servers:
-                try:                   
-                    await self.check_for_motion(camera_name)
+                try:
+                    # For cameras without clips, check if they now have their first clip
+                    if camera_name in self.cam_manager.cameras_without_clips:
+                        log.debug(f"{camera_name}: checking for first clip...")
+                        await self.check_for_first_clip(camera_name)
+                    else:
+                        # For cameras with clips, check for new motion
+                        await self.check_for_motion(camera_name)
                 except Exception as e:
                     log.error(f"{camera_name}: error checking for motion: {e}")
                     self.stream_servers[camera_name].close()
@@ -97,6 +165,12 @@ class Application:
 
                     # create new stream server
                     ss_new = await self.start_stream(camera_name, redownload=True)
+                    if ss_new is None:
+                        # Still no clips available, keep the old server and try again later
+                        log.debug(f"{camera_name}: still no clips available, will retry later")
+                        ss.datetime_started = datetime.now()
+                        continue
+                    
                     ss_new.failure_count = ss.failure_count + 1
                     ss_new.datetime_started = datetime.now()
 

--- a/blinkbridge/main.py
+++ b/blinkbridge/main.py
@@ -36,11 +36,14 @@ class Application:
         else:
             log.info(f"{camera_name}: starting stream server")
         
-        stream_server = StreamServer(camera_name)
-        stream_server.start_server(file_name_initial_video)  
-        self.stream_servers[camera_name] = stream_server
-
-        return stream_server
+        try:
+            stream_server = StreamServer(camera_name)
+            stream_server.start_server(file_name_initial_video)  
+            self.stream_servers[camera_name] = stream_server
+            return stream_server
+        except Exception as e:
+            log.error(f"{camera_name}: failed to start stream server: {e}")
+            return None
 
     async def check_for_motion(self, camera_name: str) -> bool:
         ss = self.stream_servers[camera_name]

--- a/blinkbridge/stream_server.py
+++ b/blinkbridge/stream_server.py
@@ -82,26 +82,38 @@ class StreamServer:
 
         # make still video from input video
         log.debug(f"{self.stream_name}: starting creating next still video {next_still_video}")
-        svc = StillVideoCreator(file_name_input_video,
-                                output_duration=CONFIG['still_video_duration'],
-                                file_name_still_video=next_still_video)
-        
-        # wait for enqueued video to start
-        if not still_only:
-            log.debug(f"{self.stream_name}: waiting for new video to start")
-            wait_until_file_open(file_name_input_video, self.process.pid)
+        try:
+            svc = StillVideoCreator(file_name_input_video,
+                                    output_duration=CONFIG['still_video_duration'],
+                                    file_name_still_video=next_still_video)
             
-        # enqueue next still video
-        log.debug(f'{self.stream_name}: waiting for still video creation to finish')
-        svc.wait()
-        self._enqueue_clip(next_still_video)
+            # wait for enqueued video to start
+            if not still_only:
+                log.debug(f"{self.stream_name}: waiting for new video to start")
+                wait_until_file_open(file_name_input_video, self.process.pid)
+                
+            # enqueue next still video
+            log.debug(f'{self.stream_name}: waiting for still video creation to finish')
+            svc.wait()
+            
+            # Verify the still video was created successfully
+            if not next_still_video.exists():
+                raise FileNotFoundError(f"Still video was not created: {next_still_video}")
+                
+            self._enqueue_clip(next_still_video)
 
-        # delete old still video
-        if self.current_still_video and not still_only:
-            log.debug(f'{self.stream_name}: deleting old still video {self.current_still_video}')
-            self.current_still_video.unlink()
-        
-        self.current_still_video = next_still_video
+            # delete old still video
+            if self.current_still_video and not still_only:
+                log.debug(f'{self.stream_name}: deleting old still video {self.current_still_video}')
+                self.current_still_video.unlink()
+            
+            self.current_still_video = next_still_video
+        except Exception as e:
+            log.error(f"{self.stream_name}: Failed to create still video: {e}")
+            # Clean up if still video was partially created
+            if next_still_video.exists():
+                next_still_video.unlink()
+            raise
     
     def is_running(self) -> bool:
         return self.process.poll() is None


### PR DESCRIPTION
There is an issue where a clip may not have audio (usually audio being disabled on the camera). This causes streams to fail to start. This fixes the issue by adding a silent audio track if there is no audio.

This depends on:
- https://github.com/roger-/blinkbridge/pull/18